### PR TITLE
fix(deps): pin setuptools<81 to restore pkg_resources (fleet CI)

### DIFF
--- a/dev.in
+++ b/dev.in
@@ -1,5 +1,5 @@
 pip
-setuptools
+setuptools<81  # pin <81: setuptools 82 removed pkg_resources; modules run tox with -W error::DeprecationWarning
 wheel
 tox
 tox-py

--- a/py310-dev.txt
+++ b/py310-dev.txt
@@ -268,7 +268,7 @@ pip==26.1.2 \
     --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
     --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
     # via -r dev.in
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
     # via -r dev.in

--- a/py311-dev.txt
+++ b/py311-dev.txt
@@ -205,7 +205,7 @@ pip==26.1.2 \
     --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
     --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
     # via -r dev.in
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
     # via -r dev.in

--- a/py312-dev.txt
+++ b/py312-dev.txt
@@ -205,7 +205,7 @@ pip==26.1.2 \
     --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
     --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
     # via -r dev.in
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
     # via -r dev.in

--- a/py313-dev.txt
+++ b/py313-dev.txt
@@ -205,7 +205,7 @@ pip==26.1.2 \
     --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
     --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
     # via -r dev.in
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
     # via -r dev.in

--- a/py314-dev.txt
+++ b/py314-dev.txt
@@ -205,7 +205,7 @@ pip==26.1.2 \
     --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
     --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
     # via -r dev.in
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
     # via -r dev.in

--- a/py39-dev.txt
+++ b/py39-dev.txt
@@ -272,7 +272,7 @@ pip==26.0.1 \
     --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b \
     --hash=sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8
     # via -r dev.in
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
     # via -r dev.in


### PR DESCRIPTION
## Root cause
`setuptools==82.0.0` (released 2026-02-08) **removed `pkg_resources`**. The dev locks here had auto-upgraded to `setuptools==82.0.1`. Because every `django-*` module's tox installs `pyNN-dev.txt` live from this repo's `main`, any module whose test-time dependencies still `import pkg_resources` now fails CI with:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

Confirmed on `DLRSP/django-sp` PR #379 (`ci / Python 3.10 · Django 4.2`). This is a fleet-wide breakage of the dependency-upgrade / CI matrix jobs.

## Fix
- `dev.in`: `setuptools` -> `setuptools<81` (resolves to 80.9.0, the last known-good that still ships `pkg_resources` without raising under `-W error::DeprecationWarning`).
- Regenerate the `pyNN-dev.txt` locks (setuptools `82.0.1` -> `80.9.0` with hashes).

`verify-requirements` checks that `dev.in` compiles and the committed locks install (dry-run); both hold.

## Impact
Unblocks the `ci` matrix on django-sp, django-iubenda, django-requests-api and other modules importing `pkg_resources` at test time.

Refs: github-actions-pitfalls (new pattern P-019), setuptools NEWS v82.0.0 (#3085).